### PR TITLE
feat: render screens in the builder nav order

### DIFF
--- a/pwa_build/after_migrate.py
+++ b/pwa_build/after_migrate.py
@@ -8,6 +8,7 @@ from frappe.query_builder import DocType
 class AfterMigrate:
 	def __init__(self):
 		self.sync_pwa_forms()
+		apply_nav_order()
 
 	def sync_pwa_forms(self):
 		apps = frappe.get_installed_apps()
@@ -23,6 +24,26 @@ class AfterMigrate:
 				# print each progress bar on new line
 				print()
 							
+def apply_nav_order():
+	"""Stamp modified timestamps in reverse nav order so the bundled frontend's
+	default `modified desc` listing renders screens in the designed flow order."""
+	from frappe.utils import add_to_date, now_datetime
+
+	rows = []
+	for doctype in ("PWA Form", "PWA Dashboard"):
+		rows += [(doctype, row.name, row.nav_order) for row in frappe.get_all(doctype, fields=["name", "nav_order"])]
+
+	if not any(row[2] for row in rows):
+		return
+
+	rows.sort(key=lambda row: (row[2] is None, row[2] or 0))
+	base = now_datetime()
+	for position, (doctype, name, _nav_order) in enumerate(rows):
+		frappe.db.set_value(
+			doctype, name, "modified", add_to_date(base, seconds=-position), update_modified=False
+		)
+
+
 def import_forms(file_path):
 	try:
 		docs = import_file.read_doc_from_file(file_path)

--- a/pwa_build/pwa_build/doctype/pwa_dashboard/pwa_dashboard.json
+++ b/pwa_build/pwa_build/doctype/pwa_dashboard/pwa_dashboard.json
@@ -8,6 +8,7 @@
   "form_name",
   "column_break_udhj",
   "doctype_name",
+  "nav_order",
   "fields_section",
   "pwa_dashboard_fields",
   "more_info_section",
@@ -52,12 +53,19 @@
    "fieldtype": "JSON",
    "label": "PWA Dashboard Fields",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "Position of this screen in the app navigation (lower comes first).",
+   "fieldname": "nav_order",
+   "fieldtype": "Int",
+   "label": "Nav Order"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-13 15:50:05.230620",
+ "modified": "2026-07-09 13:00:00.000000",
  "modified_by": "Administrator",
  "module": "Pwa Build",
  "name": "PWA Dashboard",

--- a/pwa_build/pwa_build/doctype/pwa_form/pwa_form.json
+++ b/pwa_build/pwa_build/doctype/pwa_form/pwa_form.json
@@ -9,6 +9,7 @@
   "parent_form",
   "column_break_udhj",
   "doctype_name",
+  "nav_order",
   "is_submittable",
   "is_child_table",
   "fields_section",
@@ -73,12 +74,19 @@
    "fieldtype": "JSON",
    "label": "PWA Form Fields",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "Position of this screen in the app navigation (lower comes first).",
+   "fieldname": "nav_order",
+   "fieldtype": "Int",
+   "label": "Nav Order"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-03-13 15:50:20.691623",
+ "modified": "2026-07-09 13:00:00.000000",
  "modified_by": "Administrator",
  "module": "Pwa Build",
  "name": "PWA Form",


### PR DESCRIPTION
The bundled frontend lists screens with no order_by, so they render in default modified-desc order, i.e. effectively arbitrary.

Adds a nav_order field to PWA Form and PWA Dashboard (imported from the exported form JSONs) and, after each sync, stamps modified timestamps in reverse nav order so the existing bundles render screens exactly in the flow designed in the builder. Legacy exports without nav_order are untouched.

Verified on a live site: seeded forms with nav order contradicting insertion order and the default listing follows nav order after migrate. Companion exporter PR on pwa-builder stamps nav_order into the exported JSONs.